### PR TITLE
Added non-CardView based adapter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
         classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.7.1'
-        classpath 'com.android.tools.build:gradle:2.0.0-beta2'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }
 }

--- a/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/DividerItemDecoration.java
+++ b/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/DividerItemDecoration.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2016 Kane O'Riley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.oriley.homage.recyclerview;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+
+public class DividerItemDecoration extends RecyclerView.ItemDecoration {
+
+    int mOrientation = -1;
+    private Drawable mDivider;
+
+    public DividerItemDecoration(Context context, boolean darkMode) {
+        int divider = darkMode ? R.drawable.homage_divider_dark : R.drawable.homage_divider_light;
+        mDivider = ContextCompat.getDrawable(context, divider);
+    }
+
+    @Override
+    public void getItemOffsets(Rect outRect, View view, RecyclerView parent,
+                               RecyclerView.State state) {
+        super.getItemOffsets(outRect, view, parent, state);
+        if (mDivider == null) {
+            return;
+        }
+
+        int position = parent.getChildAdapterPosition(view);
+        if (position == RecyclerView.NO_POSITION || position == 0) {
+            return;
+        }
+
+        if (mOrientation == -1)
+            getOrientation(parent);
+
+        if (mOrientation == LinearLayoutManager.VERTICAL) {
+            outRect.top = mDivider.getIntrinsicHeight();
+        } else {
+            outRect.left = mDivider.getIntrinsicWidth();
+        }
+    }
+
+    @Override
+    public void onDrawOver(Canvas c, RecyclerView parent, RecyclerView.State state) {
+        if (mDivider == null) {
+            super.onDrawOver(c, parent, state);
+            return;
+        }
+
+        // Initialization needed to avoid compiler warning
+        int left = 0, right = 0, top = 0, bottom = 0, size;
+        int orientation = mOrientation != -1 ? mOrientation : getOrientation(parent);
+        int childCount = parent.getChildCount();
+
+        if (orientation == LinearLayoutManager.VERTICAL) {
+            size = mDivider.getIntrinsicHeight();
+            left = parent.getPaddingLeft();
+            right = parent.getWidth() - parent.getPaddingRight();
+        } else { //horizontal
+            size = mDivider.getIntrinsicWidth();
+            top = parent.getPaddingTop();
+            bottom = parent.getHeight() - parent.getPaddingBottom();
+        }
+
+        for (int i = 1; i < childCount; i++) {
+            View child = parent.getChildAt(i);
+            RecyclerView.LayoutParams params = (RecyclerView.LayoutParams) child.getLayoutParams();
+
+            if (orientation == LinearLayoutManager.VERTICAL) {
+                top = child.getTop() - params.topMargin - size;
+                bottom = top + size;
+            } else { //horizontal
+                left = child.getLeft() - params.leftMargin;
+                right = left + size;
+            }
+            mDivider.setBounds(left, top, right, bottom);
+            mDivider.draw(c);
+        }
+    }
+
+    private int getOrientation(RecyclerView parent) {
+        if (mOrientation == -1) {
+            if (parent.getLayoutManager() instanceof LinearLayoutManager) {
+                LinearLayoutManager layoutManager = (LinearLayoutManager) parent.getLayoutManager();
+                mOrientation = layoutManager.getOrientation();
+            } else {
+                throw new IllegalStateException(
+                        "DividerItemDecoration can only be used with a LinearLayoutManager.");
+            }
+        }
+        return mOrientation;
+    }
+}

--- a/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageAdapter.java
+++ b/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageAdapter.java
@@ -1,59 +1,21 @@
-/*
- * Copyright (C) 2016 Kane O'Riley
- *
- * Licensed under the Apache License, Version 2.0 (the "License")
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package me.oriley.homage.recyclerview;
 
 import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
 import me.oriley.homage.Homage;
-import me.oriley.homage.Library;
-import me.oriley.homage.recyclerview.HomageView.ExtraInfoMode;
 
-import java.util.List;
+public class HomageAdapter extends HomageAdapterBase {
 
-@SuppressWarnings({"unused", "WeakerAccess"})
-public class HomageAdapter extends RecyclerView.Adapter<HomageViewHolder> {
-
-    @NonNull
-    protected final Homage mHomage;
-
-    protected final List<Library> mLibraries;
-
-    private final ExtraInfoMode mExtraInfoMode;
-
-    private final boolean mShowIcons;
-
-    private final boolean mDark;
-
-
-    public HomageAdapter(@NonNull Homage homage, @NonNull ExtraInfoMode extraInfoMode, boolean showIcons) {
-        this(homage, extraInfoMode, showIcons, false);
+    public HomageAdapter(@NonNull Homage homage, @NonNull HomageView.ExtraInfoMode extraInfoMode, boolean showIcons) {
+        super(homage, extraInfoMode, showIcons);
     }
 
-    public HomageAdapter(@NonNull Homage homage, @NonNull ExtraInfoMode extraInfoMode, boolean showIcons, boolean dark) {
-        mHomage = homage;
-        mLibraries = mHomage.getLibraries();
-        mExtraInfoMode = extraInfoMode;
-        mShowIcons = showIcons;
-        mDark = dark;
+    public HomageAdapter(@NonNull Homage homage, @NonNull HomageView.ExtraInfoMode extraInfoMode, boolean showIcons, boolean dark) {
+        super(homage, extraInfoMode, showIcons, dark);
     }
-
 
     @Override
     public HomageViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
@@ -61,27 +23,6 @@ public class HomageAdapter extends RecyclerView.Adapter<HomageViewHolder> {
                 .inflate(mDark ? R.layout.homage_recycler_item_dark : R.layout.homage_recycler_item_light, parent, false);
         view.setExtraInfoMode(mExtraInfoMode);
         view.setShowIcons(mShowIcons);
-        return new HomageViewHolder(view);
-    }
-
-    @Override
-    public void onBindViewHolder(final HomageViewHolder holder, int position) {
-        holder.setLibrary(getItem(position));
-        holder.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                holder.showExtraInfo();
-            }
-        });
-    }
-
-    @NonNull
-    public Library getItem(int position) {
-        return mLibraries.get(position);
-    }
-
-    @Override
-    public int getItemCount() {
-        return mLibraries.size();
+        return new HomageViewHolder(view, view);
     }
 }

--- a/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageAdapter.java
+++ b/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageAdapter.java
@@ -1,8 +1,23 @@
+/*
+ * Copyright (C) 2016 Kane O'Riley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package me.oriley.homage.recyclerview;
 
 import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import me.oriley.homage.Homage;

--- a/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageAdapterBase.java
+++ b/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageAdapterBase.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2016 Kane O'Riley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.oriley.homage.recyclerview;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+
+import java.util.List;
+
+import me.oriley.homage.Homage;
+import me.oriley.homage.Library;
+import me.oriley.homage.recyclerview.HomageView.ExtraInfoMode;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+abstract class HomageAdapterBase extends RecyclerView.Adapter<HomageViewHolder> {
+
+    @NonNull
+    protected final Homage mHomage;
+
+    protected final List<Library> mLibraries;
+
+    protected final ExtraInfoMode mExtraInfoMode;
+
+    protected final boolean mShowIcons;
+
+    protected final boolean mDark;
+
+    public HomageAdapterBase(@NonNull Homage homage, @NonNull ExtraInfoMode extraInfoMode, boolean showIcons) {
+        this(homage, extraInfoMode, showIcons, false);
+    }
+
+    public HomageAdapterBase(@NonNull Homage homage, @NonNull ExtraInfoMode extraInfoMode, boolean showIcons, boolean dark) {
+        mHomage = homage;
+        mLibraries = mHomage.getLibraries();
+        mExtraInfoMode = extraInfoMode;
+        mShowIcons = showIcons;
+        mDark = dark;
+    }
+
+    @Override
+    public void onBindViewHolder(final HomageViewHolder holder, int position) {
+        holder.setLibrary(getItem(position));
+        holder.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                holder.showExtraInfo();
+            }
+        });
+    }
+
+    @NonNull
+    public Library getItem(int position) {
+        return mLibraries.get(position);
+    }
+
+    @Override
+    public int getItemCount() {
+        return mLibraries.size();
+    }
+}

--- a/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageCardAdapter.java
+++ b/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageCardAdapter.java
@@ -1,0 +1,29 @@
+package me.oriley.homage.recyclerview;
+
+import android.support.annotation.NonNull;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import me.oriley.homage.Homage;
+
+public class HomageCardAdapter extends HomageAdapterBase {
+
+    public HomageCardAdapter(@NonNull Homage homage, @NonNull HomageView.ExtraInfoMode extraInfoMode, boolean showIcons) {
+        super(homage, extraInfoMode, showIcons);
+    }
+
+    public HomageCardAdapter(@NonNull Homage homage, @NonNull HomageView.ExtraInfoMode extraInfoMode, boolean showIcons, boolean dark) {
+        super(homage, extraInfoMode, showIcons, dark);
+    }
+
+    @Override
+    public HomageViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(mDark ? R.layout.homage_recycler_card_dark : R.layout.homage_recycler_card_light, parent, false);
+        HomageView homage = (HomageView) view.findViewById(R.id.homageView);
+        homage.setExtraInfoMode(mExtraInfoMode);
+        homage.setShowIcons(mShowIcons);
+        return new HomageViewHolder(view, homage);
+    }
+}

--- a/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageCardAdapter.java
+++ b/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageCardAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 Kane O'Riley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package me.oriley.homage.recyclerview;
 
 import android.support.annotation.NonNull;

--- a/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageCardAdapter.java
+++ b/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageCardAdapter.java
@@ -21,7 +21,7 @@ public class HomageCardAdapter extends HomageAdapterBase {
     public HomageViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext())
                 .inflate(mDark ? R.layout.homage_recycler_card_dark : R.layout.homage_recycler_card_light, parent, false);
-        HomageView homage = (HomageView) view.findViewById(R.id.homageView);
+        HomageView homage = (HomageView) view.findViewById(R.id.homage_view);
         homage.setExtraInfoMode(mExtraInfoMode);
         homage.setShowIcons(mShowIcons);
         return new HomageViewHolder(view, homage);

--- a/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageExpandableCardView.java
+++ b/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageExpandableCardView.java
@@ -22,20 +22,20 @@ import android.content.Context;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v7.widget.CardView;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewStub;
 import android.view.animation.AccelerateDecelerateInterpolator;
+import android.widget.FrameLayout;
 import android.widget.TextView;
 
 import static android.view.View.MeasureSpec.AT_MOST;
 import static android.view.View.MeasureSpec.UNSPECIFIED;
 
 @SuppressWarnings({"WeakerAccess", "unused"})
-public abstract class HomageExpandableCardView extends CardView {
+public abstract class HomageExpandableCardView extends FrameLayout {
 
     private static final int EXPAND_ANIMATION_MILLIS = 250;
 
@@ -52,7 +52,6 @@ public abstract class HomageExpandableCardView extends CardView {
     private View mExpandedView;
 
     private boolean mAnimating;
-
 
     public HomageExpandableCardView(@NonNull Context context) {
         this(context, null);
@@ -71,7 +70,6 @@ public abstract class HomageExpandableCardView extends CardView {
         mCollapsedView = mCollapsedStub;
         mExpandedView = mExpandedStub;
     }
-
 
     protected void setCollapsedLayoutResource(@LayoutRes int layoutResource) {
         if (mCollapsedStub.getLayoutResource() != layoutResource) {

--- a/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageExpandableView.java
+++ b/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageExpandableView.java
@@ -35,7 +35,7 @@ import static android.view.View.MeasureSpec.AT_MOST;
 import static android.view.View.MeasureSpec.UNSPECIFIED;
 
 @SuppressWarnings({"WeakerAccess", "unused"})
-public abstract class HomageExpandableCardView extends FrameLayout {
+public abstract class HomageExpandableView extends FrameLayout {
 
     private static final int EXPAND_ANIMATION_MILLIS = 250;
 
@@ -53,15 +53,15 @@ public abstract class HomageExpandableCardView extends FrameLayout {
 
     private boolean mAnimating;
 
-    public HomageExpandableCardView(@NonNull Context context) {
+    public HomageExpandableView(@NonNull Context context) {
         this(context, null);
     }
 
-    public HomageExpandableCardView(@NonNull Context context, @Nullable AttributeSet attrs) {
+    public HomageExpandableView(@NonNull Context context, @Nullable AttributeSet attrs) {
         this(context, attrs, 0);
     }
 
-    public HomageExpandableCardView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+    public HomageExpandableView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         View.inflate(context, R.layout.homage_expandable_card_view, this);
         mCollapsedStub = (ViewStub) findViewById(R.id.homage_expandable_card_view_collapsed_stub);

--- a/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageView.java
+++ b/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageView.java
@@ -61,9 +61,6 @@ public class HomageView extends HomageExpandableView {
     @NonNull
     private ImageView mWebButton;
 
-    @NonNull
-    private View mDividerTop;
-
     @Nullable
     private Library mLibrary;
 
@@ -114,8 +111,6 @@ public class HomageView extends HomageExpandableView {
         mSummaryView = (TextView) view.findViewById(R.id.homage_view_summary);
         mChevronView = (ImageView) view.findViewById(R.id.homage_view_chevron);
         mWebButton = (ImageView) view.findViewById(R.id.homage_view_web_button);
-        mDividerTop = view.findViewById(R.id.homage_view_divider_top);
-        mDividerTop.setAlpha(0);
 
         validateNonNull(mTitleView, mIconView, mSummaryView, mChevronView, mWebButton);
 
@@ -140,7 +135,6 @@ public class HomageView extends HomageExpandableView {
     @Override
     protected void onExpandedAnimationUpdate(float level) {
         mChevronView.setRotation(CHEVRON_ROTATION_AMOUNT * level);
-        mDividerTop.setAlpha(level);
     }
 
     public void setLibrary(@Nullable Library library) {

--- a/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageView.java
+++ b/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageView.java
@@ -36,7 +36,7 @@ import static me.oriley.homage.utils.ObjectUtils.validateNonNull;
 import static me.oriley.homage.utils.StringUtils.nullToEmpty;
 
 @SuppressWarnings({"WeakerAccess", "unused"})
-public class HomageView extends HomageExpandableCardView {
+public class HomageView extends HomageExpandableView {
 
     public enum ExtraInfoMode {
         EXPANDABLE, POPUP
@@ -60,6 +60,9 @@ public class HomageView extends HomageExpandableCardView {
 
     @NonNull
     private ImageView mWebButton;
+
+    @NonNull
+    private View mDividerTop;
 
     @Nullable
     private Library mLibrary;
@@ -111,6 +114,8 @@ public class HomageView extends HomageExpandableCardView {
         mSummaryView = (TextView) view.findViewById(R.id.homage_view_summary);
         mChevronView = (ImageView) view.findViewById(R.id.homage_view_chevron);
         mWebButton = (ImageView) view.findViewById(R.id.homage_view_web_button);
+        mDividerTop = view.findViewById(R.id.homage_view_divider_top);
+        mDividerTop.setAlpha(0);
 
         validateNonNull(mTitleView, mIconView, mSummaryView, mChevronView, mWebButton);
 
@@ -135,6 +140,7 @@ public class HomageView extends HomageExpandableCardView {
     @Override
     protected void onExpandedAnimationUpdate(float level) {
         mChevronView.setRotation(CHEVRON_ROTATION_AMOUNT * level);
+        mDividerTop.setAlpha(level);
     }
 
     public void setLibrary(@Nullable Library library) {

--- a/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageViewHolder.java
+++ b/homage-recyclerview/src/main/java/me/oriley/homage/recyclerview/HomageViewHolder.java
@@ -28,12 +28,10 @@ public class HomageViewHolder extends RecyclerView.ViewHolder {
     @NonNull
     private final HomageView mLibraryView;
 
-
-    public HomageViewHolder(@NonNull HomageView view) {
+    public HomageViewHolder(View view, @NonNull HomageView homage) {
         super(view);
-        mLibraryView = view;
+        mLibraryView = homage;
     }
-
 
     @NonNull
     public HomageView getLibraryView() {

--- a/homage-recyclerview/src/main/res/drawable/homage_divider_dark.xml
+++ b/homage-recyclerview/src/main/res/drawable/homage_divider_dark.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
@@ -15,8 +15,13 @@
   ~ limitations under the License.
   -->
 
-<me.oriley.homage.recyclerview.HomageView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="?attr/cardBackgroundColor"
-    android:theme="@style/Homage.Dark" />
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <size
+        android:width="1dp"
+        android:height="1dp" />
+
+    <solid android:color="@color/homage_divider_dark" />
+
+</shape>

--- a/homage-recyclerview/src/main/res/drawable/homage_divider_light.xml
+++ b/homage-recyclerview/src/main/res/drawable/homage_divider_light.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
@@ -15,8 +15,13 @@
   ~ limitations under the License.
   -->
 
-<me.oriley.homage.recyclerview.HomageView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="?attr/cardBackgroundColor"
-    android:theme="@style/Homage.Dark" />
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <size
+        android:width="1dp"
+        android:height="1dp" />
+
+    <solid android:color="@color/homage_divider_light" />
+
+</shape>

--- a/homage-recyclerview/src/main/res/layout/homage_recycler_card_dark.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_recycler_card_dark.xml
@@ -17,16 +17,16 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:theme="@style/HomageCard.Dark"
+    android:theme="@style/Homage.Dark.Card"
     app:cardBackgroundColor="?attr/cardBackgroundColor"
-    app:cardCornerRadius="@dimen/homage_recycler_item_corner_radius"
-    app:cardElevation="@dimen/homage_recycler_item_elevation"
+    app:cardCornerRadius="@dimen/homage_recycler_card_corner_radius"
+    app:cardElevation="@dimen/homage_recycler_card_elevation"
     app:cardPreventCornerOverlap="false"
     app:cardUseCompatPadding="true"
-    app:contentPadding="@dimen/homage_recycler_item_content_padding">
+    app:contentPadding="@dimen/homage_recycler_card_content_padding">
 
     <me.oriley.homage.recyclerview.HomageView
-        android:id="@+id/homageView"
+        android:id="@+id/homage_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/homage-recyclerview/src/main/res/layout/homage_recycler_card_dark.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_recycler_card_dark.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2016 Kane O'Riley
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License")
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:theme="@style/HomageCard.Dark"
+    app:cardBackgroundColor="?attr/cardBackgroundColor"
+    app:cardCornerRadius="@dimen/homage_recycler_item_corner_radius"
+    app:cardElevation="@dimen/homage_recycler_item_elevation"
+    app:cardPreventCornerOverlap="false"
+    app:cardUseCompatPadding="true"
+    app:contentPadding="@dimen/homage_recycler_item_content_padding">
+
+    <me.oriley.homage.recyclerview.HomageView
+        android:id="@+id/homageView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</android.support.v7.widget.CardView>

--- a/homage-recyclerview/src/main/res/layout/homage_recycler_card_dark.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_recycler_card_dark.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License")

--- a/homage-recyclerview/src/main/res/layout/homage_recycler_card_light.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_recycler_card_light.xml
@@ -17,16 +17,16 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:theme="@style/HomageCard.Light"
+    android:theme="@style/Homage.Light.Card"
     app:cardBackgroundColor="?attr/cardBackgroundColor"
-    app:cardCornerRadius="@dimen/homage_recycler_item_corner_radius"
-    app:cardElevation="@dimen/homage_recycler_item_elevation"
+    app:cardCornerRadius="@dimen/homage_recycler_card_corner_radius"
+    app:cardElevation="@dimen/homage_recycler_card_elevation"
     app:cardPreventCornerOverlap="false"
     app:cardUseCompatPadding="true"
-    app:contentPadding="@dimen/homage_recycler_item_content_padding">
+    app:contentPadding="@dimen/homage_recycler_card_content_padding">
 
     <me.oriley.homage.recyclerview.HomageView
-        android:id="@+id/homageView"
+        android:id="@+id/homage_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/homage-recyclerview/src/main/res/layout/homage_recycler_card_light.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_recycler_card_light.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License")

--- a/homage-recyclerview/src/main/res/layout/homage_recycler_card_light.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_recycler_card_light.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2016 Kane O'Riley
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License")
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:theme="@style/HomageCard.Light"
+    app:cardBackgroundColor="?attr/cardBackgroundColor"
+    app:cardCornerRadius="@dimen/homage_recycler_item_corner_radius"
+    app:cardElevation="@dimen/homage_recycler_item_elevation"
+    app:cardPreventCornerOverlap="false"
+    app:cardUseCompatPadding="true"
+    app:contentPadding="@dimen/homage_recycler_item_content_padding">
+
+    <me.oriley.homage.recyclerview.HomageView
+        android:id="@+id/homageView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</android.support.v7.widget.CardView>

--- a/homage-recyclerview/src/main/res/layout/homage_recycler_item_dark.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_recycler_item_dark.xml
@@ -19,4 +19,4 @@
     android:layout_height="wrap_content"
     android:background="?attr/cardBackgroundColor"
     android:padding="16dp"
-    android:theme="@style/HomageCard.Dark" />
+    android:theme="@style/Homage.Dark" />

--- a/homage-recyclerview/src/main/res/layout/homage_recycler_item_dark.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_recycler_item_dark.xml
@@ -18,5 +18,4 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/cardBackgroundColor"
-    android:padding="16dp"
     android:theme="@style/Homage.Dark" />

--- a/homage-recyclerview/src/main/res/layout/homage_recycler_item_dark.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_recycler_item_dark.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License")
@@ -15,15 +14,9 @@
   ~ limitations under the License.
   -->
 
-<me.oriley.homage.recyclerview.HomageView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:theme="@style/HomageCard.Dark"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:cardBackgroundColor="?attr/cardBackgroundColor"
-        app:contentPadding="@dimen/homage_recycler_item_content_padding"
-        app:cardElevation="@dimen/homage_recycler_item_elevation"
-        app:cardCornerRadius="@dimen/homage_recycler_item_corner_radius"
-        app:cardPreventCornerOverlap="false"
-        app:cardUseCompatPadding="true"/>
+<me.oriley.homage.recyclerview.HomageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/cardBackgroundColor"
+    android:padding="16dp"
+    android:theme="@style/HomageCard.Dark" />

--- a/homage-recyclerview/src/main/res/layout/homage_recycler_item_light.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_recycler_item_light.xml
@@ -18,5 +18,4 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/cardBackgroundColor"
-    android:padding="16dp"
-    android:theme="@style/HomageCard.Light" />
+    android:theme="@style/Homage.Light" />

--- a/homage-recyclerview/src/main/res/layout/homage_recycler_item_light.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_recycler_item_light.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License")
@@ -15,15 +14,9 @@
   ~ limitations under the License.
   -->
 
-<me.oriley.homage.recyclerview.HomageView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:theme="@style/HomageCard.Light"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:cardBackgroundColor="?attr/cardBackgroundColor"
-        app:contentPadding="@dimen/homage_recycler_item_content_padding"
-        app:cardElevation="@dimen/homage_recycler_item_elevation"
-        app:cardCornerRadius="@dimen/homage_recycler_item_corner_radius"
-        app:cardPreventCornerOverlap="false"
-        app:cardUseCompatPadding="true"/>
+<me.oriley.homage.recyclerview.HomageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/cardBackgroundColor"
+    android:padding="16dp"
+    android:theme="@style/HomageCard.Light" />

--- a/homage-recyclerview/src/main/res/layout/homage_recycler_item_light.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_recycler_item_light.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License")

--- a/homage-recyclerview/src/main/res/layout/homage_view_collapsed_layout.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_view_collapsed_layout.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License")
@@ -15,71 +14,84 @@
   ~ limitations under the License.
   -->
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
 
-    <ImageView
+    <View
+        android:id="@+id/homage_view_divider_top"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/homage_divider_height"
+        android:background="?attr/homageExpandedTopBottomDividerColor" />
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="?attr/homageInnerPadding">
+
+        <ImageView
             android:id="@+id/homage_view_icon"
             android:layout_width="@android:dimen/app_icon_size"
             android:layout_height="@android:dimen/app_icon_size"
             android:layout_centerVertical="true"
-            android:layout_marginRight="@dimen/homage_recycler_item_content_padding"
-            tools:ignore="ContentDescription"/>
+            android:layout_marginRight="@dimen/homage_recycler_card_content_padding"
+            tools:ignore="ContentDescription" />
 
-    <TextView
+        <TextView
             android:id="@+id/homage_view_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_toRightOf="@+id/homage_view_icon"
             android:layout_toLeftOf="@+id/homage_view_web_button"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:textColor="?attr/homageTextPrimaryColor"
+            android:layout_toRightOf="@+id/homage_view_icon"
             android:ellipsize="end"
             android:singleLine="true"
-            tools:ignore="RtlHardcoded"/>
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="?attr/homageTextPrimaryColor"
+            tools:ignore="RtlHardcoded" />
 
-    <TextView
+        <TextView
             android:id="@+id/homage_view_summary"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_below="@id/homage_view_title"
-            android:layout_toRightOf="@+id/homage_view_icon"
             android:layout_toLeftOf="@id/homage_view_web_button"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:textColor="?attr/homageTextSecondaryColor"
+            android:layout_toRightOf="@+id/homage_view_icon"
             android:ellipsize="end"
             android:singleLine="true"
-            tools:ignore="RtlHardcoded"/>
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?attr/homageTextSecondaryColor"
+            tools:ignore="RtlHardcoded" />
 
-    <ImageView
-            style="@style/HomageButtonView"
+        <ImageView
             android:id="@id/homage_view_web_button"
+            style="@style/HomageButtonView"
             android:layout_width="36dp"
             android:layout_height="36dp"
             android:layout_centerVertical="true"
             android:layout_toLeftOf="@+id/homage_view_chevron_container"
+            android:background="?android:attr/selectableItemBackground"
             android:padding="6dp"
             android:src="?attr/homageLinkDrawable"
-            android:background="?android:attr/selectableItemBackground"
-            tools:ignore="ContentDescription,RtlHardcoded"/>
+            tools:ignore="ContentDescription,RtlHardcoded" />
 
-    <FrameLayout
+        <FrameLayout
             android:id="@+id/homage_view_chevron_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
-            android:layout_alignParentRight="true">
+            android:layout_alignParentRight="true"
+            android:layout_centerVertical="true">
 
-        <ImageView
+            <ImageView
                 android:id="@+id/homage_view_chevron"
                 android:layout_width="18dp"
                 android:layout_height="18dp"
                 android:layout_marginLeft="8dp"
                 android:src="?attr/homageChevronDrawable"
-                tools:ignore="ContentDescription,RtlHardcoded"/>
+                tools:ignore="ContentDescription,RtlHardcoded" />
 
-    </FrameLayout>
+        </FrameLayout>
 
-</RelativeLayout>
+    </RelativeLayout>
+
+</FrameLayout>

--- a/homage-recyclerview/src/main/res/layout/homage_view_collapsed_layout.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_view_collapsed_layout.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License")
@@ -18,12 +19,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
-
-    <View
-        android:id="@+id/homage_view_divider_top"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/homage_divider_height"
-        android:background="?attr/homageExpandedTopBottomDividerColor" />
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/homage-recyclerview/src/main/res/layout/homage_view_expanded_layout.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_view_expanded_layout.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License")
@@ -81,13 +82,5 @@
         </LinearLayout>
 
     </HorizontalScrollView>
-
-    <View
-        android:id="@+id/homage_view_expanded_divider_bottom"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/homage_divider_height"
-        android:layout_marginBottom="@dimen/homage_expanded_view_divider_vertical_margin"
-        android:layout_marginTop="@dimen/homage_expanded_view_divider_vertical_margin"
-        android:background="?attr/homageExpandedTopBottomDividerColor" />
 
 </LinearLayout>

--- a/homage-recyclerview/src/main/res/layout/homage_view_expanded_layout.xml
+++ b/homage-recyclerview/src/main/res/layout/homage_view_expanded_layout.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License")
@@ -15,69 +14,80 @@
   ~ limitations under the License.
   -->
 
-<LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <View android:id="@+id/homage_view_expanded_divider"
-          android:layout_width="match_parent"
-          android:layout_height="@dimen/homage_divider_height"
-          android:layout_marginTop="@dimen/homage_expanded_view_divider_vertical_margin"
-          android:layout_marginBottom="@dimen/homage_expanded_view_divider_vertical_margin"
-          android:background="?attr/homageDividerColor"/>
+    <View
+        android:id="@+id/homage_view_expanded_divider"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/homage_divider_height"
+        android:layout_marginBottom="?attr/homageDividerVerticalMargin"
+        android:layout_marginTop="?attr/homageDividerVerticalMargin"
+        android:background="?attr/homageDividerColor" />
 
     <TextView
-            android:id="@+id/homage_view_expanded_description"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="@dimen/homage_expanded_view_description_padding"
-            android:layout_marginBottom="@dimen/homage_expanded_view_description_margin_bottom"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:textColor="?attr/homageTextPrimaryColor"/>
+        android:id="@+id/homage_view_expanded_description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/homage_expanded_view_description_margin_bottom"
+        android:padding="?attr/homageDescriptionPadding"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textColor="?attr/homageTextPrimaryColor" />
 
     <HorizontalScrollView
-            android:id="@+id/homage_view_expanded_license_holder"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?attr/homageLicenseBackgroundColor">
+        android:id="@+id/homage_view_expanded_license_holder"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="none"
+        android:background="?attr/homageLicenseBackgroundColor"
+        android:paddingLeft="?attr/homageInnerPadding"
+        android:paddingRight="?attr/homageInnerPadding">
 
         <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:scrollbars="horizontal">
+
+            <TextView
+                android:id="@+id/homage_view_expanded_license_name"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:scrollbars="horizontal"
-                android:orientation="vertical">
+                android:padding="@dimen/homage_expanded_view_license_text_padding"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="?attr/homageTextPrimaryColor"
+                android:textSize="@dimen/homage_license_title_text_size" />
 
             <TextView
-                    android:id="@+id/homage_view_expanded_license_name"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:padding="@dimen/homage_expanded_view_license_text_padding"
-                    android:textAppearance="?android:attr/textAppearanceMedium"
-                    android:textColor="?attr/homageTextPrimaryColor"
-                    android:textSize="@dimen/homage_license_title_text_size"/>
+                android:id="@+id/homage_view_expanded_license_rights"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/homage_expanded_view_license_text_padding"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="?attr/homageTextPrimaryColor"
+                android:textSize="@dimen/homage_license_rights_text_size" />
 
             <TextView
-                    android:id="@+id/homage_view_expanded_license_rights"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:padding="@dimen/homage_expanded_view_license_text_padding"
-                    android:textAppearance="?android:attr/textAppearanceMedium"
-                    android:textColor="?attr/homageTextPrimaryColor"
-                    android:textSize="@dimen/homage_license_rights_text_size"/>
-
-            <TextView
-                    android:id="@+id/homage_view_expanded_license_description"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:padding="@dimen/homage_expanded_view_license_text_padding"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?attr/homageTextSecondaryColor"
-                    android:textSize="@dimen/homage_license_description_text_size"/>
+                android:id="@+id/homage_view_expanded_license_description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/homage_expanded_view_license_text_padding"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:textColor="?attr/homageTextSecondaryColor"
+                android:textSize="@dimen/homage_license_description_text_size" />
 
         </LinearLayout>
 
     </HorizontalScrollView>
+
+    <View
+        android:id="@+id/homage_view_expanded_divider_bottom"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/homage_divider_height"
+        android:layout_marginBottom="@dimen/homage_expanded_view_divider_vertical_margin"
+        android:layout_marginTop="@dimen/homage_expanded_view_divider_vertical_margin"
+        android:background="?attr/homageExpandedTopBottomDividerColor" />
 
 </LinearLayout>

--- a/homage-recyclerview/src/main/res/values/attrs.xml
+++ b/homage-recyclerview/src/main/res/values/attrs.xml
@@ -24,7 +24,6 @@
         <attr name="homageDividerColor" format="color" />
         <attr name="homageChevronDrawable" format="reference" />
         <attr name="homageLinkDrawable" format="reference" />
-        <attr name="homageExpandedTopBottomDividerColor" format="color" />
         <attr name="homageInnerPadding" format="dimension" />
         <attr name="homageDescriptionPadding" format="dimension" />
         <attr name="homageDividerVerticalMargin" format="dimension" />

--- a/homage-recyclerview/src/main/res/values/attrs.xml
+++ b/homage-recyclerview/src/main/res/values/attrs.xml
@@ -24,6 +24,10 @@
         <attr name="homageDividerColor" format="color" />
         <attr name="homageChevronDrawable" format="reference" />
         <attr name="homageLinkDrawable" format="reference" />
+        <attr name="homageExpandedTopBottomDividerColor" format="color" />
+        <attr name="homageInnerPadding" format="dimension" />
+        <attr name="homageDescriptionPadding" format="dimension" />
+        <attr name="homageDividerVerticalMargin" format="dimension" />
     </declare-styleable>
 
 </resources>

--- a/homage-recyclerview/src/main/res/values/dimens.xml
+++ b/homage-recyclerview/src/main/res/values/dimens.xml
@@ -17,11 +17,13 @@
 
 <resources>
 
-    <dimen name="homage_divider_height">2px</dimen>
+    <dimen name="homage_divider_height">1dp</dimen>
 
-    <dimen name="homage_recycler_item_content_padding">12dp</dimen>
-    <dimen name="homage_recycler_item_corner_radius">2dp</dimen>
-    <dimen name="homage_recycler_item_elevation">2dp</dimen>
+    <dimen name="homage_recycler_card_content_padding">12dp</dimen>
+    <dimen name="homage_recycler_card_corner_radius">2dp</dimen>
+    <dimen name="homage_recycler_card_elevation">2dp</dimen>
+
+    <dimen name="homage_recycler_item_content_padding">16dp</dimen>
 
     <dimen name="homage_license_title_text_size">12sp</dimen>
     <dimen name="homage_license_rights_text_size">10sp</dimen>

--- a/homage-recyclerview/src/main/res/values/styles.xml
+++ b/homage-recyclerview/src/main/res/values/styles.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License")
@@ -21,26 +20,47 @@
         <item name="android:background">?android:attr/selectableItemBackground</item>
     </style>
 
-    <style name="HomageCard"/>
+    <style name="Homage">
+        <item name="homageInnerPadding">@dimen/homage_recycler_item_content_padding</item>
+        <item name="homageDividerVerticalMargin">0dp</item>
+        <item name="homageDividerColor">@android:color/transparent</item>
+        <item name="homageDescriptionPadding">@dimen/homage_recycler_item_content_padding</item>
+    </style>
 
-    <style name="HomageCard.Light">
+    <style name="Homage.Light">
         <item name="cardBackgroundColor">@color/homage_card_background_light</item>
         <item name="homageTextPrimaryColor">@color/homage_text_primary_light</item>
         <item name="homageTextSecondaryColor">@color/homage_text_secondary_light</item>
         <item name="homageLicenseBackgroundColor">@color/homage_license_background_light</item>
-        <item name="homageDividerColor">@color/homage_divider_light</item>
+        <item name="homageExpandedTopBottomDividerColor">@color/homage_divider_light</item>
         <item name="homageChevronDrawable">@drawable/homage_down_chevron_light</item>
         <item name="homageLinkDrawable">@drawable/homage_ic_link_light</item>
     </style>
 
-    <style name="HomageCard.Dark">
+    <style name="Homage.Dark">
         <item name="cardBackgroundColor">@color/homage_card_background_dark</item>
         <item name="homageTextPrimaryColor">@color/homage_text_primary_dark</item>
         <item name="homageTextSecondaryColor">@color/homage_text_secondary_dark</item>
         <item name="homageLicenseBackgroundColor">@color/homage_license_background_dark</item>
-        <item name="homageDividerColor">@color/homage_divider_dark</item>
+        <item name="homageExpandedTopBottomDividerColor">@color/homage_divider_dark</item>
         <item name="homageChevronDrawable">@drawable/homage_down_chevron_dark</item>
         <item name="homageLinkDrawable">@drawable/homage_ic_link_dark</item>
+    </style>
+
+    <style name="Homage.Light.Card">
+        <item name="homageDividerColor">@color/homage_divider_light</item>
+        <item name="homageExpandedTopBottomDividerColor">@android:color/transparent</item>
+        <item name="homageDividerVerticalMargin">@dimen/homage_expanded_view_divider_vertical_margin</item>
+        <item name="homageInnerPadding">0dp</item>
+        <item name="homageDescriptionPadding">@dimen/homage_expanded_view_description_padding</item>
+    </style>
+
+    <style name="Homage.Dark.Card">
+        <item name="homageDividerColor">@color/homage_divider_dark</item>
+        <item name="homageExpandedTopBottomDividerColor">@android:color/transparent</item>
+        <item name="homageDividerVerticalMargin">@dimen/homage_expanded_view_divider_vertical_margin</item>
+        <item name="homageInnerPadding">0dp</item>
+        <item name="homageDescriptionPadding">@dimen/homage_expanded_view_description_padding</item>
     </style>
 
     <style name="HomagePopupDialog" parent="@android:style/Theme.Dialog">

--- a/homage-recyclerview/src/main/res/values/styles.xml
+++ b/homage-recyclerview/src/main/res/values/styles.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License")
@@ -32,7 +33,6 @@
         <item name="homageTextPrimaryColor">@color/homage_text_primary_light</item>
         <item name="homageTextSecondaryColor">@color/homage_text_secondary_light</item>
         <item name="homageLicenseBackgroundColor">@color/homage_license_background_light</item>
-        <item name="homageExpandedTopBottomDividerColor">@color/homage_divider_light</item>
         <item name="homageChevronDrawable">@drawable/homage_down_chevron_light</item>
         <item name="homageLinkDrawable">@drawable/homage_ic_link_light</item>
     </style>
@@ -42,14 +42,12 @@
         <item name="homageTextPrimaryColor">@color/homage_text_primary_dark</item>
         <item name="homageTextSecondaryColor">@color/homage_text_secondary_dark</item>
         <item name="homageLicenseBackgroundColor">@color/homage_license_background_dark</item>
-        <item name="homageExpandedTopBottomDividerColor">@color/homage_divider_dark</item>
         <item name="homageChevronDrawable">@drawable/homage_down_chevron_dark</item>
         <item name="homageLinkDrawable">@drawable/homage_ic_link_dark</item>
     </style>
 
     <style name="Homage.Light.Card">
         <item name="homageDividerColor">@color/homage_divider_light</item>
-        <item name="homageExpandedTopBottomDividerColor">@android:color/transparent</item>
         <item name="homageDividerVerticalMargin">@dimen/homage_expanded_view_divider_vertical_margin</item>
         <item name="homageInnerPadding">0dp</item>
         <item name="homageDescriptionPadding">@dimen/homage_expanded_view_description_padding</item>
@@ -57,7 +55,6 @@
 
     <style name="Homage.Dark.Card">
         <item name="homageDividerColor">@color/homage_divider_dark</item>
-        <item name="homageExpandedTopBottomDividerColor">@android:color/transparent</item>
         <item name="homageDividerVerticalMargin">@dimen/homage_expanded_view_divider_vertical_margin</item>
         <item name="homageInnerPadding">0dp</item>
         <item name="homageDescriptionPadding">@dimen/homage_expanded_view_description_padding</item>

--- a/homage-sample/src/main/java/me/oriley/homagesample/DarkCardPopupFragment.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/DarkCardPopupFragment.java
@@ -26,7 +26,7 @@ import me.oriley.homage.Homage;
 import me.oriley.homage.recyclerview.HomageView;
 
 @SuppressWarnings("WeakerAccess")
-public final class DarkPopupFragment extends RecyclerViewFragment {
+public final class DarkCardPopupFragment extends RecyclerViewFragment {
 
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
@@ -43,7 +43,7 @@ public final class DarkPopupFragment extends RecyclerViewFragment {
         homage.addLicense("oriley", R.string.license_oriley_name, R.string.license_oriley_url, R.string.license_oriley_description);
         homage.refreshLibraries();
 
-        return new HomageInfiniteAdapter(homage, HomageView.ExtraInfoMode.POPUP, true, true);
+        return new HomageInfiniteCardAdapter(homage, HomageView.ExtraInfoMode.POPUP, true, true);
     }
 
     @NonNull

--- a/homage-sample/src/main/java/me/oriley/homagesample/DarkExpandableCardFragment.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/DarkExpandableCardFragment.java
@@ -22,17 +22,16 @@ import android.support.annotation.Nullable;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
-
 import me.oriley.homage.Homage;
 import me.oriley.homage.recyclerview.HomageView;
 
 @SuppressWarnings("WeakerAccess")
-public final class ExpandableIconFragment extends RecyclerViewFragment {
+public final class DarkExpandableCardFragment extends RecyclerViewFragment {
 
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        mRecyclerView.setPadding(0, 0, 0, 0);
+        view.setBackgroundResource(R.color.window_background_dark);
     }
 
     @NonNull
@@ -44,7 +43,7 @@ public final class ExpandableIconFragment extends RecyclerViewFragment {
         homage.addLicense("oriley", R.string.license_oriley_name, R.string.license_oriley_url, R.string.license_oriley_description);
         homage.refreshLibraries();
 
-        return new HomageInfiniteAdapter(homage, HomageView.ExtraInfoMode.EXPANDABLE, true);
+        return new HomageInfiniteCardAdapter(homage, HomageView.ExtraInfoMode.EXPANDABLE, true, true);
     }
 
     @NonNull

--- a/homage-sample/src/main/java/me/oriley/homagesample/DarkPopupFragment.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/DarkPopupFragment.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 Kane O'Riley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.oriley.homagesample;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+
+import me.oriley.homage.Homage;
+import me.oriley.homage.recyclerview.HomageView;
+
+@SuppressWarnings("WeakerAccess")
+public final class DarkPopupFragment extends RecyclerViewFragment {
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        view.setBackgroundResource(R.color.window_background_dark);
+        mRecyclerView.setPadding(0, 0, 0, 0);
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.Adapter createAdapter() {
+        Homage homage = new Homage(getActivity(), R.raw.licenses_nextfaze, R.raw.licenses_oriley, R.raw.licenses_base);
+
+        // Adds a custom license definition to enable matching in your JSON list
+        homage.addLicense("oriley", R.string.license_oriley_name, R.string.license_oriley_url, R.string.license_oriley_description);
+        homage.refreshLibraries();
+
+        return new HomageInfiniteAdapter(homage, HomageView.ExtraInfoMode.POPUP, false, true);
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.LayoutManager getLayoutManager() {
+        return new LinearLayoutManager(getActivity());
+    }
+}

--- a/homage-sample/src/main/java/me/oriley/homagesample/DarkPopupFragment.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/DarkPopupFragment.java
@@ -24,6 +24,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
 import me.oriley.homage.Homage;
+import me.oriley.homage.recyclerview.DividerItemDecoration;
 import me.oriley.homage.recyclerview.HomageView;
 
 @SuppressWarnings("WeakerAccess")
@@ -34,6 +35,7 @@ public final class DarkPopupFragment extends RecyclerViewFragment {
         super.onViewCreated(view, savedInstanceState);
         view.setBackgroundResource(R.color.window_background_dark);
         mRecyclerView.setPadding(0, 0, 0, 0);
+        mRecyclerView.addItemDecoration(new DividerItemDecoration(getContext(), true));
     }
 
     @NonNull

--- a/homage-sample/src/main/java/me/oriley/homagesample/ExpandableCardFragment.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/ExpandableCardFragment.java
@@ -23,7 +23,7 @@ import me.oriley.homage.Homage;
 import me.oriley.homage.recyclerview.HomageView;
 
 @SuppressWarnings("WeakerAccess")
-public final class PopupFragment extends RecyclerViewFragment {
+public final class ExpandableCardFragment extends RecyclerViewFragment {
 
     @NonNull
     @Override
@@ -34,7 +34,7 @@ public final class PopupFragment extends RecyclerViewFragment {
         homage.addLicense("oriley", R.string.license_oriley_name, R.string.license_oriley_url, R.string.license_oriley_description);
         homage.refreshLibraries();
 
-        return new HomageInfiniteAdapter(homage, HomageView.ExtraInfoMode.POPUP, false);
+        return new HomageInfiniteCardAdapter(homage, HomageView.ExtraInfoMode.EXPANDABLE, false);
     }
 
     @NonNull

--- a/homage-sample/src/main/java/me/oriley/homagesample/ExpandableCardIconFragment.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/ExpandableCardIconFragment.java
@@ -23,7 +23,7 @@ import me.oriley.homage.Homage;
 import me.oriley.homage.recyclerview.HomageView;
 
 @SuppressWarnings("WeakerAccess")
-public final class ExpandableFragment extends RecyclerViewFragment {
+public final class ExpandableCardIconFragment extends RecyclerViewFragment {
 
     @NonNull
     @Override
@@ -34,7 +34,7 @@ public final class ExpandableFragment extends RecyclerViewFragment {
         homage.addLicense("oriley", R.string.license_oriley_name, R.string.license_oriley_url, R.string.license_oriley_description);
         homage.refreshLibraries();
 
-        return new HomageInfiniteAdapter(homage, HomageView.ExtraInfoMode.EXPANDABLE, false);
+        return new HomageInfiniteCardAdapter(homage, HomageView.ExtraInfoMode.EXPANDABLE, true);
     }
 
     @NonNull

--- a/homage-sample/src/main/java/me/oriley/homagesample/ExpandableFragment.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/ExpandableFragment.java
@@ -24,6 +24,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
 import me.oriley.homage.Homage;
+import me.oriley.homage.recyclerview.DividerItemDecoration;
 import me.oriley.homage.recyclerview.HomageView;
 
 @SuppressWarnings("WeakerAccess")
@@ -33,6 +34,7 @@ public final class ExpandableFragment extends RecyclerViewFragment {
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         mRecyclerView.setPadding(0, 0, 0, 0);
+        mRecyclerView.addItemDecoration(new DividerItemDecoration(getContext(), false));
     }
 
     @NonNull

--- a/homage-sample/src/main/java/me/oriley/homagesample/ExpandableFragment.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/ExpandableFragment.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 Kane O'Riley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.oriley.homagesample;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+
+import me.oriley.homage.Homage;
+import me.oriley.homage.recyclerview.HomageView;
+
+@SuppressWarnings("WeakerAccess")
+public final class ExpandableFragment extends RecyclerViewFragment {
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        mRecyclerView.setPadding(0, 0, 0, 0);
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.Adapter createAdapter() {
+        Homage homage = new Homage(getActivity(), R.raw.licenses_nextfaze, R.raw.licenses_oriley, R.raw.licenses_base);
+
+        // Adds a custom license definition to enable matching in your JSON list
+        homage.addLicense("oriley", R.string.license_oriley_name, R.string.license_oriley_url, R.string.license_oriley_description);
+        homage.refreshLibraries();
+
+        return new HomageInfiniteAdapter(homage, HomageView.ExtraInfoMode.EXPANDABLE, false);
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.LayoutManager getLayoutManager() {
+        return new LinearLayoutManager(getActivity());
+    }
+}

--- a/homage-sample/src/main/java/me/oriley/homagesample/ExpandableIconFragment.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/ExpandableIconFragment.java
@@ -24,6 +24,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
 import me.oriley.homage.Homage;
+import me.oriley.homage.recyclerview.DividerItemDecoration;
 import me.oriley.homage.recyclerview.HomageView;
 
 @SuppressWarnings("WeakerAccess")
@@ -33,6 +34,7 @@ public final class ExpandableIconFragment extends RecyclerViewFragment {
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         mRecyclerView.setPadding(0, 0, 0, 0);
+        mRecyclerView.addItemDecoration(new DividerItemDecoration(getContext(), false));
     }
 
     @NonNull

--- a/homage-sample/src/main/java/me/oriley/homagesample/HomageInfiniteCardAdapter.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/HomageInfiniteCardAdapter.java
@@ -20,17 +20,17 @@ import android.support.annotation.NonNull;
 
 import me.oriley.homage.Homage;
 import me.oriley.homage.Library;
-import me.oriley.homage.recyclerview.HomageAdapter;
+import me.oriley.homage.recyclerview.HomageCardAdapter;
 import me.oriley.homage.recyclerview.HomageView.ExtraInfoMode;
 
-class HomageInfiniteAdapter extends HomageAdapter {
+class HomageInfiniteCardAdapter extends HomageCardAdapter {
 
-    HomageInfiniteAdapter(@NonNull Homage homage, @NonNull ExtraInfoMode extraInfoMode, boolean showIcons) {
+    HomageInfiniteCardAdapter(@NonNull Homage homage, @NonNull ExtraInfoMode extraInfoMode, boolean showIcons) {
         this(homage, extraInfoMode, showIcons, false);
     }
 
-    HomageInfiniteAdapter(@NonNull Homage homage, @NonNull ExtraInfoMode extraInfoMode, boolean showIcons,
-                          boolean dark) {
+    HomageInfiniteCardAdapter(@NonNull Homage homage, @NonNull ExtraInfoMode extraInfoMode, boolean showIcons,
+                              boolean dark) {
         super(homage, extraInfoMode, showIcons, dark);
     }
 

--- a/homage-sample/src/main/java/me/oriley/homagesample/MainActivity.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/MainActivity.java
@@ -131,6 +131,12 @@ public class MainActivity extends AppCompatActivity
             case R.id.nav_expandable_no_card:
                 openDrawerFragment(ExpandableIconFragment.class, id);
                 break;
+            case R.id.nav_expandable_no_card_no_icons:
+                openDrawerFragment(ExpandableFragment.class, id);
+                break;
+            case R.id.nav_dark_popup_no_card_no_icons:
+                openDrawerFragment(DarkPopupFragment.class, id);
+                break;
         }
 
         closeDrawer();

--- a/homage-sample/src/main/java/me/oriley/homagesample/MainActivity.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/MainActivity.java
@@ -111,22 +111,25 @@ public class MainActivity extends AppCompatActivity
         // Handle navigation view item clicks here.
         switch (id) {
             case R.id.nav_expandable:
-                openDrawerFragment(ExpandableIconFragment.class, id);
+                openDrawerFragment(ExpandableCardIconFragment.class, id);
                 break;
             case R.id.nav_popup:
-                openDrawerFragment(PopupIconFragment.class, id);
+                openDrawerFragment(PopupCardIconFragment.class, id);
                 break;
             case R.id.nav_expandable_no_icons:
-                openDrawerFragment(ExpandableFragment.class, id);
+                openDrawerFragment(ExpandableCardFragment.class, id);
                 break;
             case R.id.nav_popup_no_icons:
-                openDrawerFragment(PopupFragment.class, id);
+                openDrawerFragment(PopupCardFragment.class, id);
                 break;
             case R.id.nav_dark_expandable:
-                openDrawerFragment(DarkExpandableFragment.class, id);
+                openDrawerFragment(DarkExpandableCardFragment.class, id);
                 break;
             case R.id.nav_dark_popup:
-                openDrawerFragment(DarkPopupFragment.class, id);
+                openDrawerFragment(DarkCardPopupFragment.class, id);
+                break;
+            case R.id.nav_expandable_no_card:
+                openDrawerFragment(ExpandableIconFragment.class, id);
                 break;
         }
 

--- a/homage-sample/src/main/java/me/oriley/homagesample/PopupCardFragment.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/PopupCardFragment.java
@@ -16,23 +16,14 @@
 
 package me.oriley.homagesample;
 
-import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.view.View;
 import me.oriley.homage.Homage;
 import me.oriley.homage.recyclerview.HomageView;
 
 @SuppressWarnings("WeakerAccess")
-public final class DarkExpandableFragment extends RecyclerViewFragment {
-
-    @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        view.setBackgroundResource(R.color.window_background_dark);
-    }
+public final class PopupCardFragment extends RecyclerViewFragment {
 
     @NonNull
     @Override
@@ -43,7 +34,7 @@ public final class DarkExpandableFragment extends RecyclerViewFragment {
         homage.addLicense("oriley", R.string.license_oriley_name, R.string.license_oriley_url, R.string.license_oriley_description);
         homage.refreshLibraries();
 
-        return new HomageInfiniteAdapter(homage, HomageView.ExtraInfoMode.EXPANDABLE, true, true);
+        return new HomageInfiniteCardAdapter(homage, HomageView.ExtraInfoMode.POPUP, false);
     }
 
     @NonNull

--- a/homage-sample/src/main/java/me/oriley/homagesample/PopupCardIconFragment.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/PopupCardIconFragment.java
@@ -23,7 +23,7 @@ import me.oriley.homage.Homage;
 import me.oriley.homage.recyclerview.HomageView;
 
 @SuppressWarnings("WeakerAccess")
-public final class PopupIconFragment extends RecyclerViewFragment {
+public final class PopupCardIconFragment extends RecyclerViewFragment {
 
     @NonNull
     @Override
@@ -34,7 +34,7 @@ public final class PopupIconFragment extends RecyclerViewFragment {
         homage.addLicense("oriley", R.string.license_oriley_name, R.string.license_oriley_url, R.string.license_oriley_description);
         homage.refreshLibraries();
 
-        return new HomageInfiniteAdapter(homage, HomageView.ExtraInfoMode.POPUP, true);
+        return new HomageInfiniteCardAdapter(homage, HomageView.ExtraInfoMode.POPUP, true);
     }
 
     @NonNull

--- a/homage-sample/src/main/java/me/oriley/homagesample/RecyclerViewFragment.java
+++ b/homage-sample/src/main/java/me/oriley/homagesample/RecyclerViewFragment.java
@@ -33,7 +33,7 @@ abstract class RecyclerViewFragment extends Fragment {
     private static final String KEY_LAYOUT_MANAGER_STATE = "layoutManagerState";
 
     @NonNull
-    private RecyclerView mRecyclerView;
+    protected RecyclerView mRecyclerView;
 
     @Nullable
     private RecyclerView.Adapter mAdapter;

--- a/homage-sample/src/main/res/menu/activity_main_drawer.xml
+++ b/homage-sample/src/main/res/menu/activity_main_drawer.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2016 Kane O'Riley
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License")
@@ -19,27 +18,32 @@
 
     <group android:checkableBehavior="single">
         <item
-                android:id="@+id/nav_expandable"
-                android:title="@string/drawer_expandable"/>
+            android:id="@+id/nav_expandable"
+            android:title="@string/drawer_expandable" />
         <item
-                android:id="@+id/nav_popup"
-                android:title="@string/drawer_popup"/>
+            android:id="@+id/nav_popup"
+            android:title="@string/drawer_popup" />
         <item
-                android:id="@+id/nav_expandable_no_icons"
-                android:title="@string/drawer_expandable_no_icon"/>
+            android:id="@+id/nav_expandable_no_icons"
+            android:title="@string/drawer_expandable_no_icon" />
         <item
-                android:id="@+id/nav_popup_no_icons"
-                android:title="@string/drawer_popup_no_icon"/>
+            android:id="@+id/nav_popup_no_icons"
+            android:title="@string/drawer_popup_no_icon" />
         <item
-                android:id="@+id/nav_dark_expandable"
-                android:title="@string/drawer_dark_expandable"/>
+            android:id="@+id/nav_dark_expandable"
+            android:title="@string/drawer_dark_expandable" />
         <item
             android:id="@+id/nav_dark_popup"
-            android:title="@string/drawer_dark_popup"/>
-
+            android:title="@string/drawer_dark_popup" />
         <item
             android:id="@+id/nav_expandable_no_card"
-            android:title="@string/drawer_expandable_no_card"/>
+            android:title="@string/drawer_expandable_no_card" />
+        <item
+            android:id="@+id/nav_expandable_no_card_no_icons"
+            android:title="@string/drawer_expandable_no_card_no_icon" />
+        <item
+            android:id="@+id/nav_dark_popup_no_card_no_icons"
+            android:title="@string/drawer_dark_popup_no_card_no_icon" />
     </group>
 
 </menu>

--- a/homage-sample/src/main/res/menu/activity_main_drawer.xml
+++ b/homage-sample/src/main/res/menu/activity_main_drawer.xml
@@ -34,8 +34,12 @@
                 android:id="@+id/nav_dark_expandable"
                 android:title="@string/drawer_dark_expandable"/>
         <item
-                android:id="@+id/nav_dark_popup"
-                android:title="@string/drawer_dark_popup"/>
+            android:id="@+id/nav_dark_popup"
+            android:title="@string/drawer_dark_popup"/>
+
+        <item
+            android:id="@+id/nav_expandable_no_card"
+            android:title="@string/drawer_expandable_no_card"/>
     </group>
 
 </menu>

--- a/homage-sample/src/main/res/values/strings.xml
+++ b/homage-sample/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
     <string name="drawer_dark_expandable">Expandable Dark</string>
     <string name="drawer_dark_popup">Popup Dark</string>
     <string name="drawer_expandable_no_card">Expandable w/o CardView</string>
+    <string name="drawer_expandable_no_card_no_icon">Expandable w/o CardView &amp; Icons</string>
+    <string name="drawer_dark_popup_no_card_no_icon">Popup Dark w/o CardView &amp; Icons</string>
 
     <string name="license_oriley_name">The O\'Riley License (TM)</string>
     <string name="license_oriley_url">http://oriley.me</string>

--- a/homage-sample/src/main/res/values/strings.xml
+++ b/homage-sample/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="drawer_popup_no_icon">Popup w/o Icons</string>
     <string name="drawer_dark_expandable">Expandable Dark</string>
     <string name="drawer_dark_popup">Popup Dark</string>
+    <string name="drawer_expandable_no_card">Expandable w/o CardView</string>
 
     <string name="license_oriley_name">The O\'Riley License (TM)</string>
     <string name="license_oriley_url">http://oriley.me</string>


### PR DESCRIPTION
Hey,
I refactored your current adapter so that it can be used with and without CardView.
HomageView is now a subclass of FrameLayout. For the CardView version of the adapter the layout file wraps the HomageView into a CardView.
I also added three fragments to the sample to showcase the non-CardView adapters.

Hope this matches more or less with the way how you would have implemented it ;-)

<img src="https://cloud.githubusercontent.com/assets/5631865/15744119/5b2ab9ae-28ca-11e6-807b-028ba63be0a9.png" alt="Mainscreen" width="30%" > <img src="https://cloud.githubusercontent.com/assets/5631865/15744118/5b2a8f7e-28ca-11e6-8de1-67076e62be90.png" alt="Mainscreen" width="30%" >
